### PR TITLE
Allow other versions of font-awesome.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "style-loader": "*"
   },
   "peerDependencies": {
-    "font-awesome": "~4.4.0"
+    "font-awesome": "~4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Typically, font-awesome bumps the minor version when adding new icons, which happens fairly frequently.  This library is helpful, but it's a bit annoying to see "UNMET PEER DEPENDENCY font-awesome@4.5.0" in the npm logs.
