### PR TITLE
fix for module not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require("style!css!sass!./font-awesome-sass-styles!./font-awesome-sass.config.js");
+require("style!css!sass!./font-awesome-sass-styles.loader!./font-awesome-sass.config.js");


### PR DESCRIPTION
This should work fine for both webpack 1.x and the new 2.0 beta
